### PR TITLE
Fix Registry detection for HCE executable

### DIFF
--- a/src/HCE/Detection.cs
+++ b/src/HCE/Detection.cs
@@ -112,7 +112,7 @@ namespace HXE.HCE
         const string member = "EXE Path";
         using (var key = Registry.LocalMachine.OpenSubKey(subKey))
         {
-          var path = key?.GetValue(member).ToString();
+          var path = Combine(key?.GetValue(member).ToString(), Executable);
 
           if (path != null && Exists(path))
             return new FileInfo(path);

--- a/src/HCE/Executable.cs
+++ b/src/HCE/Executable.cs
@@ -57,7 +57,7 @@ namespace HXE.HCE
     {
       var hce = Detection.Infer();
 
-      if (System.IO.File.Exists(hce.FullName))
+      if (hce != null)
         return (Executable) hce.FullName;
 
       throw new FileNotFoundException("Could not detect executable on the filesystem.");


### PR DESCRIPTION
Previously, the detection assumed the Registry key contained the full path to the executable. Instead, the key contains the full path of the folder containing the executable.

Changes made as recommended by Yumiris.