### PR TITLE
Autoprofile

### DIFF
--- a/doc/waypoint.txt
+++ b/doc/waypoint.txt
@@ -1,0 +1,27 @@
+WAYPOINT "PROFILE NAME" FILE
+=================================
+
+The waypoint file contains the path to itself and the file name is the
+profile's name with no file extension. HXE does not need this file, but
+it can be created so Halo can locate and recognize the relevant profile.
+
+INFERENCE
+---------
+
+The location of the waypoint file for the relevant profile can be implicitly
+inferred by detecting a player folder and then looking for a file with the same
+name within that folder.
+
+ANALYSIS
+--------
+
+The path of a profile's waypoint file can be either a full path or relative
+path. This path is written to the file encoded as UTF-8 with Windows CR-LF
+line endings.
+
+Examples:
+    C:\Users\user\Documents\My Games\Halo CE\savegames\<profile name>\<profile name>
+    <path parameter>\savegames\<profile name>\<profile name>
+    .\profiles\savegames\<profile name>\<profile name>
+ 
+ 

--- a/src/File.cs
+++ b/src/File.cs
@@ -53,7 +53,7 @@ namespace HXE
     {
       var baseDirectory = GetDirectoryName(Path);
 
-      if (!Directory.Exists(baseDirectory))
+      if (!Directory.Exists(GetFullPath(baseDirectory)))
         Directory.CreateDirectory(baseDirectory ?? throw new ArgumentNullException());
     }
 

--- a/src/HCE/Detection.cs
+++ b/src/HCE/Detection.cs
@@ -101,7 +101,7 @@ namespace HXE.HCE
     public static FileInfo InferFromRegistryKeyEntry()
     {
       const string keyX64 = @"SOFTWARE\Wow6432Node\Microsoft\Microsoft Games\Halo CE";
-      const string keyX32 = @"SOFTWARE\Microsoft\Microsoft Games\Halo CE";
+      const string keyX86 = @"SOFTWARE\Microsoft\Microsoft Games\Halo CE";
 
       /**
        * Seeks the HEC executable path at the given registry sub-key, and returns the path if it exists on the fs; else
@@ -121,7 +121,7 @@ namespace HXE.HCE
         }
       }
 
-      return GetFromSubKey(keyX64) ?? GetFromSubKey(keyX32);
+      return GetFromSubKey(keyX64) ?? GetFromSubKey(keyX86);
     }
   }
 }

--- a/src/HCE/Executable.cs
+++ b/src/HCE/Executable.cs
@@ -119,7 +119,7 @@ namespace HXE.HCE
          */
 
         if (!string.IsNullOrWhiteSpace(Profile.Path))
-          ApplyArgument(args, $"-path \"{GetFullPath(Profile.Path)}\" ");
+          ApplyArgument(args, $"-path \"{Profile.Path}\" ");
 
         /**
          * Miscellaneous tweaks. 

--- a/src/HCE/Executable.cs
+++ b/src/HCE/Executable.cs
@@ -21,11 +21,9 @@
 using System.Diagnostics;
 using System.IO;
 using System.Text;
-using Microsoft.Win32;
 using static System.Environment;
 using static System.IO.Path;
 using static HXE.Console;
-using static HXE.Paths;
 
 namespace HXE.HCE
 {
@@ -61,36 +59,6 @@ namespace HXE.HCE
         return (Executable) hce.FullName;
 
       throw new FileNotFoundException("Could not detect executable on the filesystem.");
-    }
-
-    /// <summary>
-    ///   Gets installation path declared in the registry.
-    ///   Use 64-bit Windows32-on-Windows64 registry path. If it does not exist, try the 32-bit path.
-    /// </summary>
-    /// <returns>
-    ///   Installation path declared in the registry. If it does not exist, null will be returned and HXE will fallback to th HXE-installer-path file.
-    /// </returns>
-    public static object GetRegistry()
-    {
-      object GetValue(RegistryView registryView)
-      {
-        const string registryLocation64 = @"SOFTWARE\WOW6432Node\Microsoft\Microsoft Games\Halo CE";
-        const string registryLocation32 = @"SOFTWARE\Microsoft\Microsoft Games\Halo CE";
-        const string registryIdentity = @"EXE Path";
-
-        using (var view = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, registryView))
-        using (var key = view.OpenSubKey(registryLocation64))
-        if (registryLocation64 != null)
-        {
-          return key.GetValue(registryIdentity);         
-        }
-        // if null, try 32-bit key-path
-        using (var view = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, registryView))
-        using (var key = view.OpenSubKey(registryLocation32))
-        return key?.GetValue(registryIdentity);
-      }
-
-      return GetValue(RegistryView.Registry32) ?? GetValue(RegistryView.Registry64);
     }
 
     public void Start()

--- a/src/HCE/LastProfile.cs
+++ b/src/HCE/LastProfile.cs
@@ -84,10 +84,16 @@ namespace HXE.HCE
         Path = name
       };
     }
+    /// <summary>
+    ///   Call Profile.Generate() and assign the generated Profile as the LastProfile.
+    /// </summary>
+    /// <param name="scaffold">Inherit and pass the bool indicating if the scaffold must be created.</param>
+    /// <param name="pathParam">Inherit and pass the -path parameter.</param>
+    /// <param name="lastProfile">Inherit the instance</param>
+    /// <param name="profile">Inherit and pass the Profile instance to Profile.Generate().</param>
     public void Generate(bool scaffold, string pathParam, LastProfile lastProfile, Profile profile)
     {
       profile.Generate(scaffold, pathParam, profile);
-      profile.Save();
 
       lastProfile.Profile = HCE.Profile.GenVars.ProfileName;
       lastProfile.Save();

--- a/src/HCE/LastProfile.cs
+++ b/src/HCE/LastProfile.cs
@@ -18,6 +18,12 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using static HXE.Console;
+using static HXE.Paths;
+
 namespace HXE.HCE
 {
   /// <inheritdoc />
@@ -48,10 +54,41 @@ namespace HXE.HCE
     /// </summary>
     public void Save()
     {
-      var data  = ReadAllText();
-      var split = data.Split('\\');
-      split[split.Length - 2] = Profile;
-      WriteAllText(string.Join("\\", split));
+      using (var fs = new FileStream(Path, FileMode.Open, FileAccess.ReadWrite))
+      using (var ms = new MemoryStream(255))
+      using (var bw = new BinaryWriter(ms))
+      {
+        var path = System.IO.Path.GetDirectoryName(Path);
+        byte[] profdir = Encoding.UTF8.GetBytes(Custom.ProfileDirectory(path, Profile));
+        byte[] delim = Encoding.UTF8.GetBytes("\\");
+        byte[] pad = { 0 };
+        byte[] blam = Encoding.UTF8.GetBytes("lam.sav");
+        List<byte> list1 = new List<byte>(profdir);
+        List<byte> list2 = new List<byte>(delim);
+        List<byte> list3 = new List<byte>(pad);
+        List<byte> list4 = new List<byte>(blam);
+
+        list1.AddRange(list2);
+        list1.AddRange(list3);
+        list1.AddRange(list4);
+        byte[] stream = list1.ToArray();
+
+        var sb = new StringBuilder("Byte Array {");
+        foreach (var b in stream)
+        {
+          sb.Append(b + " ");
+        }
+        sb.Append("}");
+        Debug(sb.ToString());
+
+        ms.Position = 0;
+        bw.Write(stream);
+
+        ms.Position = 0;
+        ms.CopyTo(fs);
+
+        Info("lastprof.txt created");
+      }
     }
 
     /// <summary>

--- a/src/HCE/LastProfile.cs
+++ b/src/HCE/LastProfile.cs
@@ -93,10 +93,13 @@ namespace HXE.HCE
     /// <param name="profile">Inherit and pass the Profile instance to Profile.Generate().</param>
     public void Generate(bool scaffold, string pathParam, LastProfile lastProfile, Profile profile)
     {
+      Console.Core("LastProfile.Generate");
       profile.Generate(scaffold, pathParam, profile);
 
-      lastProfile.Profile = HCE.Profile.GenVars.ProfileName;
-      lastProfile.Save();
+      lastProfile.Profile = profile.Details.Name;
+      
+      using (System.IO.StreamWriter lastproftxt = System.IO.File.AppendText($"{pathParam}\\lastprof.txt"))
+        lastProfile.Save();
     }
   }
 }

--- a/src/HCE/LastProfile.cs
+++ b/src/HCE/LastProfile.cs
@@ -84,5 +84,11 @@ namespace HXE.HCE
         Path = name
       };
     }
+    public static void Generate()
+    {
+      string profileName = null;
+      profileName = HXE.HCE.Profile.Generate.Name(profileName);
+      return;
+    }
   }
 }

--- a/src/HCE/LastProfile.cs
+++ b/src/HCE/LastProfile.cs
@@ -84,12 +84,9 @@ namespace HXE.HCE
         Path = name
       };
     }
-    public void Generate(bool scaffold = false)
+    public void Generate(bool scaffold, string pathParam, LastProfile lastProfile, Profile profile)
     {
-      var lastProfile = new LastProfile();
-      var profile = new HCE.Profile();
-            
-      profile.Generate(scaffold);
+      profile.Generate(scaffold, pathParam, profile);
       profile.Save();
 
       lastProfile.Profile = HCE.Profile.GenVars.ProfileName;

--- a/src/HCE/LastProfile.cs
+++ b/src/HCE/LastProfile.cs
@@ -84,22 +84,5 @@ namespace HXE.HCE
         Path = name
       };
     }
-    /// <summary>
-    ///   Call Profile.Generate() and assign the generated Profile as the LastProfile.
-    /// </summary>
-    /// <param name="scaffold">Inherit and pass the bool indicating if the scaffold must be created.</param>
-    /// <param name="pathParam">Inherit and pass the -path parameter.</param>
-    /// <param name="lastProfile">Inherit the instance</param>
-    /// <param name="profile">Inherit and pass the Profile instance to Profile.Generate().</param>
-    public void Generate(bool scaffold, string pathParam, LastProfile lastProfile, Profile profile)
-    {
-      Console.Core("LastProfile.Generate");
-      profile.Generate(scaffold, pathParam, profile);
-
-      lastProfile.Profile = profile.Details.Name;
-      
-      using (System.IO.StreamWriter lastproftxt = System.IO.File.AppendText($"{pathParam}\\lastprof.txt"))
-        lastProfile.Save();
-    }
   }
 }

--- a/src/HCE/LastProfile.cs
+++ b/src/HCE/LastProfile.cs
@@ -17,7 +17,6 @@
  *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
-//using static HXE.HCE.Profile;
 
 namespace HXE.HCE
 {
@@ -85,13 +84,16 @@ namespace HXE.HCE
         Path = name
       };
     }
-    public static void Generate()
+    public void Generate(bool scaffold = false)
     {
-      HCE.Profile.Generate();
-      HCE.Profile.Load();
-      LastProfile.Profile = HCE.Profile.ProfileDetails.Name;
-      LastProfile.Save();
-      return;
+      var lastProfile = new LastProfile();
+      var profile = new HCE.Profile();
+            
+      profile.Generate(scaffold);
+      profile.Save();
+
+      lastProfile.Profile = HCE.Profile.GenVars.ProfileName;
+      lastProfile.Save();
     }
   }
 }

--- a/src/HCE/LastProfile.cs
+++ b/src/HCE/LastProfile.cs
@@ -17,6 +17,7 @@
  *    misrepresented as being the original software.
  * 3. This notice may not be removed or altered from any source distribution.
  */
+//using static HXE.HCE.Profile;
 
 namespace HXE.HCE
 {
@@ -86,8 +87,10 @@ namespace HXE.HCE
     }
     public static void Generate()
     {
-      string profileName = null;
-      profileName = HXE.HCE.Profile.Generate.Name(profileName);
+      HCE.Profile.Generate();
+      HCE.Profile.Load();
+      LastProfile.Profile = HCE.Profile.ProfileDetails.Name;
+      LastProfile.Save();
       return;
     }
   }

--- a/src/HCE/Profile.cs
+++ b/src/HCE/Profile.cs
@@ -121,7 +121,7 @@ namespace HXE.HCE
         WriteByte(Offset.AudioVolumeEffects,         Audio.Volume.Effects);
         WriteByte(Offset.AudioVolumeMusic,           Audio.Volume.Music);
 
-        /*
+        /**
          * As for the boolean values, we convert them behind the scene to their integer equivalents -- 1 and 0 for true
          * and false, respectively.
          */

--- a/src/HCE/Profile.cs
+++ b/src/HCE/Profile.cs
@@ -384,7 +384,7 @@ namespace HXE.HCE
       var profile = (Profile) Custom.Profile(directory, lastprof.Profile);
 
       if (!profile.Exists())
-        Profile.Generate.BlamSav();
+        Profile.Generate();
       if (!profile.Exists())
         throw new FileNotFoundException("Cannot load detected profile - its blam.sav does not exist.");
 
@@ -703,33 +703,20 @@ namespace HXE.HCE
     /// <summary>
     ///   Generate lastprof.txt if it doesn't exist
     /// </summary>
-    public class Generate
+    public void Generate()
     {
-      public string Name(string profileName,string directory)
-      {
-          //LastProfile.save();
-          // todo:
-          // create the file.
-          //  if the file is still null, *then* exception
-          // load the file
-          // initialize with NULL. 'FF'
-          // populate with default settings
-          // end ProfileGen
-        string profile = (Profile) Custom.Profile(directory, LastProfile.Profile);
-  
-        if (!profile.Exists())
-        {
-          BlamSav();
-        }
-        string name = $"New{new Random().Next(1, 999).ToString("D3")}";
-        profile = name;
-        return name;
-      }
-      public void BlamSav()
-      {
-        Profile.Save();
-        return; //stub
-      }
+      //LastProfile.save();
+      // todo:
+      // create the file.
+      //  if the file is still null, *then* exception
+      // load the file
+      // populate with default settings
+      // end ProfileGen
+      string name = $"New{new Random().Next(1, 999).ToString("D3")}";
+      ProfileDetails.Name = name;
+      Profile.Save();
+
+      return;
     }
   }
 }//Detect(Paths.HCE.Directory);

--- a/src/HCE/Profile.cs
+++ b/src/HCE/Profile.cs
@@ -377,10 +377,7 @@ namespace HXE.HCE
 
       if (!lastprof.Exists())
         {
-          if (!lastprof.Exists())
-          {
             throw new FileNotFoundException("Cannot detect profile - lastprof.txt does not exist.");
-          }
         }
       lastprof.Load();
 
@@ -388,10 +385,7 @@ namespace HXE.HCE
 
       if (!profile.Exists())
         {
-          if (!profile.Exists())
-          {
-            throw new FileNotFoundException("Cannot load detected profile - its blam.sav does not exist.");
-          }
+          throw new FileNotFoundException("Cannot load detected profile - its blam.sav does not exist.");
         }
 
       profile.Load();
@@ -704,21 +698,19 @@ namespace HXE.HCE
       public Dictionary<Action, Button> Mapping = new Dictionary<Action, Button>();
     }
 
-    /// <inheritdoc />
     /// <summary>
-    ///   Generate lastprof.txt if it doesn't exist
+    ///  Create retrievable variables for Profile Generation. Generate a NewXXX-style name for the new Player Profile.
     /// </summary>
-    /// 
     public class GenVars
     {
       readonly private static string NameGen = $"New{new Random().Next(1, 999).ToString("D3")}";
 
-      public static string ProfilePath = ""; // path to Waypoint file. See GenVars' GetPath() and Scaffold()'s waypoint.
+      public static string ProfilePath = ""; /// path to Waypoint file. See GenVars' GetPath() and Scaffold()'s waypoint.
       public static string ProfileName = "";
       public static string UserData = "";
       public static void GenName()
       {
-        ProfileName = NameGen; // Use once to generate a profile name. Read from ProfileName for the resulting name.
+        ProfileName = NameGen; /// Use once to generate a profile name. Read from ProfileName for the resulting name.
       }
       public static void GetProfilePath()
       {
@@ -726,38 +718,65 @@ namespace HXE.HCE
       }
     }
 
+    /// <summary>
+    /// Create file and folder structure for Profile.Generate() using variables from GenVars
+    /// </summary>
     public void Scaffold()
     {
-      // create profile files
-      // e.g., blam.sav, savegame.bin, etc.
-      // and directory structure...
-      //File. // create directory structure
-      
+      /// create directory structure 
+      /// and profile files...
+      /// e.g., blam.sav, savegame.bin, et cetera
+      Info("Creating Scaffold...\n");
 
-      using (StreamWriter blam = System.IO.File.AppendText("blam.sav")) // Create blam.sav
-      System.IO.File.WriteAllBytes("blam.sav", new byte[0x2000]); // 0x2000 == int 8192
-    
-      using (StreamWriter savegame = System.IO.File.AppendText("savegame.bin")) // Create savegame.bin
-      System.IO.File.WriteAllBytes("savegame.bin", new byte[0x480000]); // 0x480000 == int 4718592
+      Path = $"{UserData}\\savegames\\{ProfileName}\\";
+      CreateDirectory();
+      Info($"Path is currently {Path}\n"); // Doesn't write to console
+      System.Console.WriteLine($"\"{Path}\" exists? {Exists()}"); // Doesn't write to console
 
-      using (StreamWriter waypoint = System.IO.File.AppendText(ProfileName)) // Create waypoint
-      System.IO.File.WriteAllText(ProfileName, ProfilePath);
-      // ($"{GenVars.UserData}\\savegames\\{ProfileName}\\{ProfileName}");
-      // "waypoint" is used to refer to the file at "$Profile/savegames/$ProfileName/$ProfileName"
-      // Halo writes the path of this file as its contents.
-      // For instance, `.\profiles\savegames\New001\New001`
-      //   when `-path .\profiles`
+      /// Create blam.sav
+      using (StreamWriter blam = System.IO.File.AppendText($"blam.sav"))
+      {
+        Path = $"{UserData}\\savegames\\{ProfileName}\\blam.sav";
+        WriteAllBytes(new byte[0x2000]); /// 0x2000 == int 8192
+      }
+
+      /// Create savegame.bin
+      using (StreamWriter savegame = System.IO.File.AppendText($"savegame.bin"))
+      {
+        Path = $"{UserData}\\savegames\\{ProfileName}\\savegame.bin";
+        WriteAllBytes(new byte[0x480000]); /// 0x480000 == int 4718592
+      }
+
+      /// Create waypoint
+      using (StreamWriter waypoint = System.IO.File.AppendText(ProfilePath))
+      {
+        Path = ProfilePath;
+        WriteAllText(ProfilePath);
+      }
+      /// "waypoint" is used to refer to the file at "$Profile/savegames/$ProfileName/$ProfileName"
+      /// Halo writes the path of this file as its contents.
+      /// For instance, `.\profiles\savegames\New001\New001`
+      ///   when `-path .\profiles`
     }
 
+    /// <summary>
+    ///  Generate a new Player Profile. Create savegames folder and relevant file structures. 
+    /// </summary>
+    /// <param name="scaffold">bool to determine whether to execute Scaffold generation.</param>
+    /// <param name="pathParam">-path parameter to pass to Halo and write to profiles.</param>
+    /// <param name="profile">Object to represent as string.</param>
     public void Generate(bool scaffold, string pathParam, Profile profile)
     {
-      // todo:
-      // create the file. - done, but double check it
-      //  if the file is still null, *then* throw an error - done
-      // load the file
-      // populate with default settings
-      // end ProfileGen
-      // Re-use LastProfile.Generate.Path: Move relevant declarations to Kernel so LastProfile, Profile use the same instance. - done
+      /// todo:
+      ///   create the file.
+      ///     double check it
+      ///   DONE: if the file is still null, *then* throw an error.
+      ///     Do this everywhere this function is called.
+      ///   populate with default settings
+      ///     blam.sav has some defaults listed. What needs to be set manually?
+      ///   load the file
+      ///     Do I still need to do this?
+      Info("Generating new Player Profile...");
       UserData = pathParam;
 
       GenName();
@@ -765,10 +784,10 @@ namespace HXE.HCE
 
       GetProfilePath();
 
-      if (scaffold)
+      if (!scaffold)
         Scaffold();
 
-      Save();
+      profile.Save();
     }
   }
 }

--- a/src/HCE/Profile.cs
+++ b/src/HCE/Profile.cs
@@ -375,12 +375,16 @@ namespace HXE.HCE
       var lastprof = (LastProfile) Custom.LastProfile(directory);
 
       if (!lastprof.Exists())
+        LastProfile.Generate();
+      if (!lastprof.Exists())
         throw new FileNotFoundException("Cannot detect profile - lastprof.txt does not exist.");
 
       lastprof.Load();
 
       var profile = (Profile) Custom.Profile(directory, lastprof.Profile);
 
+      if (!profile.Exists())
+        Profile.Generate.BlamSav();
       if (!profile.Exists())
         throw new FileNotFoundException("Cannot load detected profile - its blam.sav does not exist.");
 
@@ -693,5 +697,39 @@ namespace HXE.HCE
 
       public Dictionary<Action, Button> Mapping = new Dictionary<Action, Button>();
     }
+    /// TEMPORARY until I figure out the best place for these changes.
+  
+    /// <inheritdoc />
+    /// <summary>
+    ///   Generate lastprof.txt if it doesn't exist
+    /// </summary>
+    public class Generate
+    {
+      public string Name(string profileName,string directory)
+      {
+          //LastProfile.save();
+          // todo:
+          // create the file.
+          //  if the file is still null, *then* exception
+          // load the file
+          // initialize with NULL. 'FF'
+          // populate with default settings
+          // end ProfileGen
+        string profile = (Profile) Custom.Profile(directory, LastProfile.Profile);
+  
+        if (!profile.Exists())
+        {
+          BlamSav();
+        }
+        string name = $"New{new Random().Next(1, 999).ToString("D3")}";
+        profile = name;
+        return name;
+      }
+      public void BlamSav()
+      {
+        Profile.Save();
+        return; //stub
+      }
+    }
   }
-}
+}//Detect(Paths.HCE.Directory);

--- a/src/HCE/Profile.cs
+++ b/src/HCE/Profile.cs
@@ -30,7 +30,6 @@ using static HXE.HCE.Profile.ProfileDetails;
 using static HXE.HCE.Profile.ProfileNetwork;
 using static HXE.HCE.Profile.ProfileVideo;
 using static HXE.HCE.Profile.ProfileInput;
-using static HXE.HCE.Profile.GenVars;
 using static HXE.Paths;
 using Directory = System.IO.Directory;
 
@@ -696,125 +695,6 @@ namespace HXE.HCE
       }
 
       public Dictionary<Action, Button> Mapping = new Dictionary<Action, Button>();
-    }
-
-    /// <summary>
-    ///  Create retrievable variables for Profile Generation. Generate a NewXXX-style name for the new Player Profile.
-    /// </summary>
-    public class GenVars
-    {
-      readonly private static string NameGen = $"New{new Random().Next(1, 999).ToString("D3")}";
-
-      /// <summary>
-      /// Waypoint file's path. See GenVars' GetWaypointPath() and Scaffold()'s waypoint streamwriter.
-      /// </summary>
-      //public static string WaypointPath = "";
-      /// <summary>
-      /// The path passed from the -path Halo parameter or the default location in %UserProfile%\\Documents\\My Games\\Halo CE\\
-      /// </summary>
-      //public static string UserData = ""; /// See Profile.Generate() for assignment.
-      /// <summary>
-      /// Assign arbitrary directory paths to this variable. To be used like a "Current Directory".
-      /// </summary>
-      public static string DirPath = "";
-
-      /// <summary>
-      /// Use once to generate a profile name. Read from ProfileName for the result.
-      /// </summary>
-      public static void SetNewName(Profile profile)
-      {
-        profile.Details.Name = NameGen;
-      }
-      /// <summary>
-      /// Assigns $"{UserData}\\savegames\\{ProfileName}\\{ProfileName}" to Waypoint Path.
-      /// </summary>
-      /*public static void SetWaypointPath(Profile profile, string pathParam)
-      {
-        WaypointPath = Custom.Waypoint(UserData, profile.Details.Name);
-      }*/
-      /// <summary>
-      /// Output the Path variable's current value. Verify its full path exists in the file system.
-      /// </summary>
-      public static void VerifyPath(string path)
-      {
-        Info($"Path is currently \"{path}\"");
-        Info($"The Full Path is \"{System.IO.Path.GetFullPath(path)}\"");
-        Info($"\"{path}\" exists? {Directory.Exists(System.IO.Path.GetFullPath(path))}");
-      }
-    }
-
-    /// <summary>
-    /// Create file and folder structure for Profile.Generate() using variables from GenVars.
-    /// </summary>
-    public void Scaffold(string pathParam, Profile profile)
-    {
-      /// and profile files...
-      /// e.g., blam.sav, savegame.bin, et cetera
-      Core("Creating Scaffold...");
-
-      //var file = new File();
-      /// Set Path to the -path parameter
-      /// Check if it exists, create it if it doesn't.
-      /// Print the full path to the console.
-      Path = pathParam;  /// e.g. ".\temp\"
-      CreateDirectory();
-      VerifyPath(Path);
-
-      /// Set Path to the savegames directory, et cetera
-      Path = Custom.Profiles(pathParam);  /// e.g. ".\temp\savegames\
-      CreateDirectory();
-      VerifyPath(Path);
-
-      /// Set Path to the current Profile's directory, et cetera
-      Path = Custom.ProfileDirectory(pathParam, Details.Name);  /// e.g. ".\temp\savegames\New001\"
-      CreateDirectory();
-      VerifyPath(Path);
-
-      /// Create blam.sav
-      using (StreamWriter blam = System.IO.File. AppendText($"{Path}\\blam.sav"))
-        WriteAllBytes(new byte[0x2000]); /// 0x2000 == int 8192
-
-      /// Create savegame.bin
-      using (StreamWriter savegame = System.IO.File.AppendText($"{Path}\\savegame.bin"))
-        WriteAllBytes(new byte[0x480000]); /// 0x480000 == int 4718592
-
-      /// Create waypoint
-      using (StreamWriter waypoint = System.IO.File.AppendText(Custom.Waypoint(pathParam, profile.Details.Name)))
-        WriteAllText(Custom.Waypoint(pathParam, profile.Details.Name));
-      /// "waypoint" is used to refer to the file at "$Profile\\savegames\\$Details.Name\\$Details.Name"
-      /// Halo writes the path of this file as the file's contents.
-      /// For instance, `.\profiles\savegames\New001\New001`
-      ///   when `-path .\profiles`
-    }
-
-    /// <summary>
-    ///  Generate a new Player Profile. Create savegames folder and relevant file structures. 
-    /// </summary>
-    /// <param name="scaffold">bool to determine whether to execute Scaffold generation.</param>
-    /// <param name="pathParam">-path parameter to pass to Halo and write to profiles.</param>
-    /// <param name="profile">Object to represent as string.</param>
-    public void Generate(bool scaffold, string pathParam, Profile profile)
-    {
-      /// todo:
-      ///   create the file.
-      ///     double check it
-      ///   DONE: if the file is still null, *then* throw an exception.
-      ///     Do this everywhere this function is called.
-      ///   populate with default settings
-      ///     blam.sav has some defaults listed. What needs to be set manually?
-      ///   load the file
-      ///     Do I still need to do this?
-      Core("Profile.Generate");
-
-      SetNewName(profile);
-
-      if (!scaffold)
-        Scaffold(pathParam, profile);
-
-      //profile.Name = Custom.Profile();
-      profile.Path = Custom.Profile(pathParam, profile.Details.Name);
-
-      profile.Save();
     }
   }
 }

--- a/src/HXE.csproj
+++ b/src/HXE.csproj
@@ -11,6 +11,21 @@
     <AssemblyName>hxe</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -52,6 +67,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="NewProfile.cs" />
     <Compile Include="Compiler.cs" />
     <Compile Include="Console.cs" />
     <Compile Include="Exceptions\AssetException.cs" />

--- a/src/Kernel.cs
+++ b/src/Kernel.cs
@@ -301,6 +301,13 @@ namespace HXE
         try
         {
           blam = Profile.Detect(executable.Profile.Path);
+          if (!blam.Exists())
+          {
+            bool scaffold = Exists(blam);
+            var lastprofile = new LastProfile();
+            var profile = new Profile();
+            lastprofile.Generate(scaffold, executable.Profile.Path, lastprofile, profile);
+          }
 
           Video();
           Audio();
@@ -380,7 +387,7 @@ namespace HXE
 
           if (configuration.Video.Uncap)
           {
-            blam.Video.FrameRate = VideoFrameRate.VsyncOff;
+            blam.Video.FrameRate = VideoFrameRate.VsyncOff; 
 
             Core("BLAM.VIDEO.UNCAP: Applied V-Sync off for framerate uncap.");
 
@@ -488,7 +495,8 @@ namespace HXE
           open.HUD.ScaleHUD                                 = true; /* fixes user interface    */
           open.Camera.IgnoreFOVChangeInCinematics           = true; /* fixes user interface    */
           open.Camera.IgnoreFOVChangeInMainMenu             = true; /* fixes user interface    */
-          open.Rasterizer.ShaderExtensions.Effect.DepthFade = true; /* shader optimisations    */
+          open.Rasterizer.ShaderExtensions.Effect.DepthFade = true; /* shader optimisations    */ 
+          // Note: DepthFade causes the edges of particles/decals to blend when they clip/intersect with other geometry
 
           open.Save();
 

--- a/src/Kernel.cs
+++ b/src/Kernel.cs
@@ -152,7 +152,7 @@ namespace HXE
             var prof = (LastProfile) Custom.LastProfile(executable.Profile.Path);
 
             if (!prof.Exists())
-              return;
+              Profile.Generate.BlamSav();
 
             prof.Load();
 

--- a/src/Kernel.cs
+++ b/src/Kernel.cs
@@ -150,22 +150,49 @@ namespace HXE
           try
           {
             var prof = (LastProfile) Custom.LastProfile(executable.Profile.Path);
-            var pathParam = executable.Profile.Path;
-            bool scaffold = System.IO.File.Exists($"{pathParam}\\savegames\\");
 
             if (!prof.Exists())
+            {
+              Core("Lastprof.txt does not Exists.");
+              bool scaffold = System.IO.File.Exists($"{executable.Profile.Path}\\savegames\\");
+              var profile = new Profile();
+              Core("Calling LastProfile.Generate()");
+              if (!scaffold)
               {
-                var lastProfile = new LastProfile();
-                var profile = new Profile();
-                prof.Generate(scaffold, pathParam, lastProfile, profile);
+                Info("Savegames scaffold doesn't exist.");
               }
+              else
+              {
+                Info("Savegames scaffold detected.");
+              }
+              prof.Generate(scaffold, executable.Profile.Path, prof, profile);
+            }
             prof.Load();
 
             var name = prof.Profile;
             var save = (Progress) Custom.Progress(executable.Profile.Path, name);
 
             if (!save.Exists())
-              return;
+            {
+              Info("Player Profile Not found.");
+              bool scaffold = System.IO.File.Exists($"{Custom.Profiles(executable.Profile.Path)}");
+              var profile = new Profile();
+              Core("Calling LastProfile.Generate()");
+              if (!scaffold)
+              {
+                Info("Savegames scaffold doesn't exist.");
+              }
+              else
+              {
+                Info("Savegames scaffold detected.");
+              }
+              prof.Generate(scaffold, executable.Profile.Path, prof, profile);
+              if(!save.Exists())
+              {
+                Info("Player Profile could not be created.");
+                return;
+              }
+            }
 
             save.Load();
 
@@ -298,28 +325,45 @@ namespace HXE
       {
         Profile blam;
 
-        try
+        for (int i = 0; i < 1; i++)
         {
-          blam = Profile.Detect(executable.Profile.Path);
-          if (!blam.Exists())
+          try
           {
-            bool scaffold = Exists(blam);
-            var lastprofile = new LastProfile();
-            var profile = new Profile();
-            lastprofile.Generate(scaffold, executable.Profile.Path, lastprofile, profile);
+            blam = Profile.Detect(executable.Profile.Path);
+
+            Video();
+            Audio();
+            Input();
+
+            blam.Save();
+
+            Core("MAIN.BLAM: Profile enhancements have been successfully applied and saved.");
           }
+          catch (Exception e)
+          {
+            Error(e.Message + " -- MAIN.BLAM HALTED");
+            try
+            {
 
-          Video();
-          Audio();
-          Input();
+              bool scaffold   = Exists(GetFullPath($"{Custom.Profiles(executable.Profile.Path)}"));
+              var lastprofile = new LastProfile();
+              blam            = new Profile();
+              Info("Calling LastProfile.Generate()");
+              lastprofile.Generate(scaffold, executable.Profile.Path, lastprofile, blam);
 
-          blam.Save();
+              Video();
+              Audio();
+              Input();
 
-          Core("MAIN.BLAM: Profile enhancements have been successfully applied and saved.");
-        }
-        catch (Exception e)
-        {
-          Error(e.Message + " -- MAIN.BLAM HALTED");
+              blam.Save();
+
+              Core("MAIN.BLAM: Profile enhancements have been successfully applied and saved.");
+            }
+            catch
+            {
+              Error(e.Message + " -- MAIN.BLAM HALTED");
+            }
+          }
         }
 
         /**

--- a/src/Kernel.cs
+++ b/src/Kernel.cs
@@ -149,49 +149,34 @@ namespace HXE
 
           try
           {
-            var prof = (LastProfile) Custom.LastProfile(executable.Profile.Path);
+            var  lastprof = (LastProfile) Custom.LastProfile(executable.Profile.Path);
 
-            if (!prof.Exists())
+            if (!lastprof.Exists())
             {
+              var  profile  = new Profile();
+              bool scaffold = false;
+
               Core("Lastprof.txt does not Exists.");
-              bool scaffold = System.IO.File.Exists($"{executable.Profile.Path}\\savegames\\");
-              var profile = new Profile();
-              Core("Calling LastProfile.Generate()");
+              Core("Calling LastProfile.Generate()...");
               if (!scaffold)
               {
-                Info("Savegames scaffold doesn't exist.");
+                Debug("Savegames scaffold doesn't exist.");
               }
               else
               {
-                Info("Savegames scaffold detected.");
+                Debug("Savegames scaffold detected.");
               }
-              NewProfile.LastProfile(scaffold, executable.Profile.Path, prof, profile);
+              NewProfile.Generate(executable.Profile.Path, lastprof, profile, scaffold);
             }
-            prof.Load();
 
-            var name = prof.Profile;
+            lastprof.Load();
+
+            var name = lastprof.Profile;
             var save = (Progress) Custom.Progress(executable.Profile.Path, name);
 
             if (!save.Exists())
             {
-              Info("Player Profile Not found.");
-              bool scaffold = System.IO.File.Exists($"{Custom.Profiles(executable.Profile.Path)}");
-              var profile = new Profile();
-              Core("Calling LastProfile.Generate()");
-              if (!scaffold)
-              {
-                Info("Savegames scaffold doesn't exist.");
-              }
-              else
-              {
-                Info("Savegames scaffold detected.");
-              }
-              NewProfile.LastProfile(scaffold, executable.Profile.Path, prof, profile);
-              if(!save.Exists())
-              {
-                Info("Player Profile could not be created.");
-                return;
-              }
+              throw new Exception("Player Profile could not be found.");
             }
 
             save.Load();
@@ -325,12 +310,12 @@ namespace HXE
       {
         Profile blam;
 
-        for (int i = 0; i < 1; i++)
+        for (int i = 0; i < 1 ; i++)
         {
           try
           {
             blam = Profile.Detect(executable.Profile.Path);
-
+             
             Video();
             Audio();
             Input();
@@ -341,25 +326,25 @@ namespace HXE
           }
           catch (Exception e)
           {
-            Error(e.Message + " -- MAIN.BLAM HALTED");
-            try
+            if (i == 0)
             {
+              blam = new Profile();
+              var lastprof = (LastProfile)Custom.LastProfile(executable.Profile.Path);
+              bool scaffold = false;
 
-              bool scaffold   = Exists(GetFullPath($"{Custom.Profiles(executable.Profile.Path)}"));
-              var lastprofile = new LastProfile();
-              blam            = new Profile();
-              Info("Calling LastProfile.Generate()");
-              NewProfile.LastProfile(scaffold, executable.Profile.Path, lastprofile, blam);
-
-              Video();
-              Audio();
-              Input();
-
-              blam.Save();
-
-              Core("MAIN.BLAM: Profile enhancements have been successfully applied and saved.");
+              Core("Lastprof.txt does not exist.");
+              Core("Calling LastProfile.Generate()...");
+              if (!scaffold)
+              {
+                Debug("Savegames scaffold doesn't exist.");
+              }
+              else
+              {
+                Debug("Savegames scaffold detected.");
+              }
+              NewProfile.Generate(executable.Profile.Path, lastprof, blam, scaffold);
             }
-            catch
+            else
             {
               Error(e.Message + " -- MAIN.BLAM HALTED");
             }
@@ -527,9 +512,31 @@ namespace HXE
       void Open()
       {
         var open = (OpenSauce) Custom.OpenSauce(executable.Profile.Path);
+        var mod = System.IO.File.Exists("./dinput8.dll") || System.IO.File.Exists("./mods/opensauce.dll");
 
-        if (open.Exists())
+        if (System.IO.File.Exists("./dinput8.dll"))
+          Debug("dinput8.dll exists");
+        else
+          Debug("dinput8 not found");
+
+        if (System.IO.File.Exists("./mods/opensauce.dll"))
+          Debug("opensauce.dll exists");
+        else
+          Debug("opensauce.dll not found");
+
+        if (!mod)
+          Debug("Open Sauce not found");
+
+        if (open.Exists() && mod)
+        { 
+          open.Load(); 
+        }
+        else if(mod)
+        {
+          open.Save();
           open.Load();
+        }
+        
 
         try
         {
@@ -540,7 +547,6 @@ namespace HXE
           open.Camera.IgnoreFOVChangeInCinematics           = true; /* fixes user interface    */
           open.Camera.IgnoreFOVChangeInMainMenu             = true; /* fixes user interface    */
           open.Rasterizer.ShaderExtensions.Effect.DepthFade = true; /* shader optimisations    */ 
-          // Note: DepthFade causes the edges of particles/decals to blend when they clip/intersect with other geometry
 
           open.Save();
 

--- a/src/Kernel.cs
+++ b/src/Kernel.cs
@@ -152,7 +152,7 @@ namespace HXE
             var prof = (LastProfile) Custom.LastProfile(executable.Profile.Path);
 
             if (!prof.Exists())
-              Profile.Generate.BlamSav();
+              Profile.Generate();
 
             prof.Load();
 

--- a/src/Kernel.cs
+++ b/src/Kernel.cs
@@ -150,10 +150,14 @@ namespace HXE
           try
           {
             var prof = (LastProfile) Custom.LastProfile(executable.Profile.Path);
+            var pathParam = executable.Profile.Path;
+            bool scaffold = System.IO.File.Exists($"{pathParam}\\savegames\\");
 
             if (!prof.Exists())
               {
-                prof.Generate();
+                var lastProfile = new LastProfile();
+                var profile = new Profile();
+                prof.Generate(scaffold, pathParam, lastProfile, profile);
               }
             prof.Load();
 

--- a/src/Kernel.cs
+++ b/src/Kernel.cs
@@ -152,8 +152,9 @@ namespace HXE
             var prof = (LastProfile) Custom.LastProfile(executable.Profile.Path);
 
             if (!prof.Exists())
-              Profile.Generate();
-
+              {
+                prof.Generate();
+              }
             prof.Load();
 
             var name = prof.Profile;

--- a/src/Kernel.cs
+++ b/src/Kernel.cs
@@ -31,8 +31,8 @@ using static System.IO.Directory;
 using static System.IO.Path;
 using static System.Windows.Forms.Screen;
 using static HXE.Console;
-using static HXE.HCE.Profile.ProfileAudio;
 using static HXE.Paths;
+using static HXE.HCE.Profile.ProfileAudio;
 using static HXE.HCE.Profile.ProfileVideo;
 using static HXE.SPV3.PostProcessing;
 using static System.Text.Encoding;
@@ -165,7 +165,7 @@ namespace HXE
               {
                 Info("Savegames scaffold detected.");
               }
-              prof.Generate(scaffold, executable.Profile.Path, prof, profile);
+              NewProfile.LastProfile(scaffold, executable.Profile.Path, prof, profile);
             }
             prof.Load();
 
@@ -186,7 +186,7 @@ namespace HXE
               {
                 Info("Savegames scaffold detected.");
               }
-              prof.Generate(scaffold, executable.Profile.Path, prof, profile);
+              NewProfile.LastProfile(scaffold, executable.Profile.Path, prof, profile);
               if(!save.Exists())
               {
                 Info("Player Profile could not be created.");
@@ -349,7 +349,7 @@ namespace HXE
               var lastprofile = new LastProfile();
               blam            = new Profile();
               Info("Calling LastProfile.Generate()");
-              lastprofile.Generate(scaffold, executable.Profile.Path, lastprofile, blam);
+              NewProfile.LastProfile(scaffold, executable.Profile.Path, lastprofile, blam);
 
               Video();
               Audio();

--- a/src/NewProfile.cs
+++ b/src/NewProfile.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.IO;
+using HXE.HCE;
+using static HXE.Console;
+using static HXE.Paths;
+using static HXE.NewProfile.GenerateVars;
+using Directory = System.IO.Directory;
+
+namespace HXE
+{
+  /// <inheritdoc />
+  /// <summary>
+  ///   Object used for creating a new Player Profile.
+  /// </summary>
+  class NewProfile : File
+  {
+    /// <summary>
+    ///   Call NewProfile.Profile() and assign the generated Profile as the LastProfile.
+    /// </summary>
+    /// <param name="scaffold"    >Inherit and pass the bool indicating if the scaffold must be created.</param>
+    /// <param name="pathParam"   >Inherit and pass the -path parameter.</param>
+    /// <param name="lastProfile" >Inherit the instance</param>
+    /// <param name="profile"     >Inherit and pass the Profile instance to Profile.Generate().</param>
+    public static void LastProfile(bool scaffold, string pathParam, LastProfile lastProfile, Profile profile)
+    {
+      Core("LastProfile.Generate");
+      Profile(scaffold, pathParam, profile);
+
+      lastProfile.Profile = profile.Details.Name;
+
+      using (StreamWriter lastproftxt = System.IO.File.AppendText($"{Custom.LastProfile(pathParam)}"))
+        lastProfile.Save();
+    }
+
+    /// <summary>
+    ///   Create retrievable variables for Profile Generation. Generate a NewXXX-style name for the new Player Profile.
+    /// </summary>
+    public class GenerateVars
+    {
+      readonly private static string NameGen = $"New{new Random().Next(1, 999).ToString("D3")}";
+
+      /// <summary>
+      ///   Use once to generate a profile name. Read from ProfileName for the result.
+      /// </summary>
+      public static void SetNewName(Profile profile)
+      {
+        profile.Details.Name = NameGen;
+      }
+
+      /// <summary>
+      ///   Assigns $"{UserData}\\savegames\\{ProfileName}\\{ProfileName}" to Waypoint Path.
+      /// </summary>
+      //public static void SetWaypointPath(Profile profile, string pathParam)
+      //{
+      //  WaypointPath = Custom.Waypoint(UserData, profile.Details.Name);
+      //}
+
+      /// <summary>
+      ///   Output the Path variable's current value. Verify its full path exists in the file system.
+      /// </summary>
+      public static void VerifyPath(string path)
+      {
+        Info($"Path is currently \"{path}\"");
+        Info($"The Full Path is \"{System.IO.Path.GetFullPath(path)}\"");
+        Info($"\"{path}\" exists? {Directory.Exists(System.IO.Path.GetFullPath(path))}");
+      }
+    }
+
+    /// <summary>
+    ///   Create file and folder structure for Profile.Generate() using variables from GenVars.
+    /// </summary>
+    /// <param name="pathParam" >-path parameter to pass to Halo and write to profiles.</param>
+    /// <param name="profile"   >Object to represent as string.</param>
+    /// <param name="file"      >An instance of the File class</param>
+    public static File Scaffold(string pathParam, Profile profile, File file)
+    {
+      /// and profile files...
+      /// e.g., blam.sav, savegame.bin, et cetera
+      Core("Creating Scaffold...");
+
+      /// Set Path to the -path parameter
+      /// Check if it exists, create it if it doesn't.
+      /// Print the full path to the console.
+      file.Path = pathParam;  /// e.g. ".\temp\"
+      file.CreateDirectory();
+      VerifyPath(file.Path);
+
+      /// Set Path to the savegames directory, et cetera
+      file.Path = Custom.Profiles(pathParam);  /// e.g. ".\temp\savegames\
+      file.CreateDirectory();
+      VerifyPath(file.Path);
+
+      /// Set Path to the current Profile's directory, et cetera
+      file.Path = Custom.ProfileDirectory(pathParam, profile.Details.Name);  /// e.g. ".\temp\savegames\New001\"
+      file.CreateDirectory();
+      VerifyPath(file.Path);
+
+      /// Create blam.sav
+      using (StreamWriter blam = System.IO.File.AppendText($"{file.Path}\\blam.sav"))
+        file.WriteAllBytes(new byte[0x2000]); /// 0x2000 == int 8192
+
+      /// Create savegame.bin
+      using (StreamWriter savegame = System.IO.File.AppendText($"{file.Path}\\savegame.bin"))
+        file.WriteAllBytes(new byte[0x480000]); /// 0x480000 == int 4718592
+
+      /// Create waypoint
+      using (StreamWriter waypoint = System.IO.File.AppendText(Custom.Waypoint(pathParam, profile.Details.Name)))
+        file.WriteAllText(Custom.Waypoint(pathParam, profile.Details.Name));
+      /// "waypoint" is used to refer to the file at "$Profile\\savegames\\$Details.Name\\$Details.Name"
+      /// Halo writes the path of this file as the file's contents.
+      /// For instance, `.\profiles\savegames\New001\New001`
+      ///   when `-path .\profiles`
+      return file;
+    }
+
+    /// <summary>
+    ///   Generate a new Player Profile. Create savegames folder and relevant file structures. 
+    /// </summary>
+    /// <param name="scaffold">Boolean to determine whether to execute Scaffold generation.</param>
+    /// <param name="path"    >-path parameter to pass to Halo and write to profiles.</param>
+    /// <param name="profile" >Object to represent as string.</param>
+    public static void Profile(bool scaffold, string path, Profile profile)
+    {
+      /// todo:
+      ///   create the file.
+      ///     double check it
+      ///   DONE: if the file is still null, *then* throw an exception.
+      ///     Do this everywhere this function is called.
+      ///   populate with default settings
+      ///     blam.sav has some defaults listed. What needs to be set manually?
+      ///   load the file
+      ///     Do I still need to do this?
+      Core("Profile.Generate");
+      var file = new File();
+      SetNewName(profile);
+      profile.Path = Custom.Profile(path, profile.Details.Name);
+
+      if (!scaffold)
+        Scaffold(path, profile, file);
+
+      profile.Save();
+    }
+  }
+}

--- a/src/NewProfile.cs
+++ b/src/NewProfile.cs
@@ -12,28 +12,40 @@ namespace HXE
   /// <summary>
   ///   Object used for creating a new Player Profile.
   /// </summary>
-  class NewProfile : File
+  class NewProfile
   {
     /// <summary>
-    ///   Call NewProfile.Profile() and assign the generated Profile as the LastProfile.
+    ///   Generate a Player Profile and assign it as the LastProfile.
     /// </summary>
     /// <param name="scaffold"    >Inherit and pass the bool indicating if the scaffold must be created.</param>
-    /// <param name="pathParam"   >Inherit and pass the -path parameter.</param>
-    /// <param name="lastProfile" >Inherit the instance</param>
-    /// <param name="profile"     >Inherit and pass the Profile instance to Profile.Generate().</param>
-    public static void LastProfile(bool scaffold, string pathParam, LastProfile lastProfile, Profile profile)
+    /// <param name="path"        >Inherit and pass the -path parameter.</param>
+    /// <param name="lastprofile" >Inherit the LastProfile instance.</param>
+    /// <param name="profile"     >Inherit the Profile instance.</param>
+    public static void Generate(string path, LastProfile lastprofile, Profile profile, bool scaffold)
     {
-      Core("LastProfile.Generate");
-      Profile(scaffold, pathParam, profile);
+      Core("Beginning to generate a new Player Profile");
+      /// todo:
+      ///   create the file.
+      ///     double check it
+      ///   DONE: if the file is still null, *then* throw an exception.
+      ///     Do this everywhere this function is called.
+      ///   populate with default settings
+      ///     blam.sav has some defaults listed. What needs to be set manually?
+      ///   load the file
+      ///     Do I still need to do this?
+      SetNewName(profile);
+      profile.Path = Custom.Profile(path, profile.Details.Name);
+      lastprofile.Profile = profile.Details.Name;
 
-      lastProfile.Profile = profile.Details.Name;
+      if (!scaffold)
+        Scaffold(path, lastprofile, profile);
 
-      using (StreamWriter lastproftxt = System.IO.File.AppendText($"{Custom.LastProfile(pathParam)}"))
-        lastProfile.Save();
+      profile.Save();
+      lastprofile.Save();
     }
 
     /// <summary>
-    ///   Create retrievable variables for Profile Generation. Generate a NewXXX-style name for the new Player Profile.
+    ///   Reusable functions for Profile Generation.
     /// </summary>
     public class GenerateVars
     {
@@ -48,97 +60,82 @@ namespace HXE
       }
 
       /// <summary>
-      ///   Assigns $"{UserData}\\savegames\\{ProfileName}\\{ProfileName}" to Waypoint Path.
-      /// </summary>
-      //public static void SetWaypointPath(Profile profile, string pathParam)
-      //{
-      //  WaypointPath = Custom.Waypoint(UserData, profile.Details.Name);
-      //}
-
-      /// <summary>
-      ///   Output the Path variable's current value. Verify its full path exists in the file system.
+      ///   Output the File.Path variable's current value. Verify its full path exists in the file system.
       /// </summary>
       public static void VerifyPath(string path)
       {
-        Info($"Path is currently \"{path}\"");
-        Info($"The Full Path is \"{System.IO.Path.GetFullPath(path)}\"");
-        Info($"\"{path}\" exists? {Directory.Exists(System.IO.Path.GetFullPath(path))}");
+        FileAttributes attr = System.IO.File.GetAttributes(path);
+        Debug("");
+        Debug($"Path is currently \"{path}\"");
+        Debug($"The Full Path is \"{Path.GetFullPath(path)}\"");
+        Debug($"Path is folder? {attr.HasFlag(FileAttributes.Directory)}");
+        if (attr.HasFlag(FileAttributes.Directory)) 
+        {
+          Debug($"\"{path}\" exists? {Directory.Exists(path)}");
+        }
+        else
+        {
+          Debug($"\"{path}\" exists? {System.IO.File.Exists(path)}");
+        }
       }
+
     }
 
     /// <summary>
     ///   Create file and folder structure for Profile.Generate() using variables from GenVars.
     /// </summary>
-    /// <param name="pathParam" >-path parameter to pass to Halo and write to profiles.</param>
+    /// <param name="path" >-path parameter to pass to Halo and write to profiles.</param>
     /// <param name="profile"   >Object to represent as string.</param>
     /// <param name="file"      >An instance of the File class</param>
-    public static File Scaffold(string pathParam, Profile profile, File file)
+    public static void Scaffold(string path, LastProfile lastprofile, Profile profile)
     {
-      /// and profile files...
-      /// e.g., blam.sav, savegame.bin, et cetera
       Core("Creating Scaffold...");
 
       /// Set Path to the -path parameter
       /// Check if it exists, create it if it doesn't.
       /// Print the full path to the console.
-      file.Path = pathParam;  /// e.g. ".\temp\"
-      file.CreateDirectory();
+      /// e.g. ".\temp\"
+      var file = (File) path;
+      Directory.CreateDirectory(file.Path);
       VerifyPath(file.Path);
 
       /// Set Path to the savegames directory, et cetera
-      file.Path = Custom.Profiles(pathParam);  /// e.g. ".\temp\savegames\
-      file.CreateDirectory();
+      file.Path = Custom.Profiles(path);  /// e.g. ".\temp\savegames\
+      Directory.CreateDirectory(file.Path);
       VerifyPath(file.Path);
 
       /// Set Path to the current Profile's directory, et cetera
-      file.Path = Custom.ProfileDirectory(pathParam, profile.Details.Name);  /// e.g. ".\temp\savegames\New001\"
-      file.CreateDirectory();
+      file.Path = Custom.ProfileDirectory(path, profile.Details.Name);  /// e.g. ".\temp\savegames\New001\"
+      Directory.CreateDirectory(file.Path);
       VerifyPath(file.Path);
 
       /// Create blam.sav
-      using (StreamWriter blam = System.IO.File.AppendText($"{file.Path}\\blam.sav"))
-        file.WriteAllBytes(new byte[0x2000]); /// 0x2000 == int 8192
+      file.Path = Custom.Profile(path, profile.Details.Name); /// e.g. ".\temp\savegames\New001\blam.sav"
+      file.WriteAllBytes(new byte[8192]);
+      VerifyPath(file.Path);
 
       /// Create savegame.bin
-      using (StreamWriter savegame = System.IO.File.AppendText($"{file.Path}\\savegame.bin"))
-        file.WriteAllBytes(new byte[0x480000]); /// 0x480000 == int 4718592
+      file.Path = Custom.Progress(path, profile.Details.Name); /// e.g. ".\temp\savegames\New001\savegame.bin"
+      file.WriteAllBytes(new byte[0x480000]); /// 0x480000 == int 4718592
+      VerifyPath(file.Path);
 
       /// Create waypoint
-      using (StreamWriter waypoint = System.IO.File.AppendText(Custom.Waypoint(pathParam, profile.Details.Name)))
-        file.WriteAllText(Custom.Waypoint(pathParam, profile.Details.Name));
-      /// "waypoint" is used to refer to the file at "$Profile\\savegames\\$Details.Name\\$Details.Name"
+      file.Path = Custom.Waypoint(path, profile.Details.Name); /// e.g. ".\temp\savegames\New001\New001"
+      file.WriteAllText(Custom.Waypoint(path, profile.Details.Name));
+      VerifyPath(file.Path);
+      /// "waypoint" is used to refer to the file at "Path\\savegames\\Name\\Name"
       /// Halo writes the path of this file as the file's contents.
       /// For instance, `.\profiles\savegames\New001\New001`
       ///   when `-path .\profiles`
-      return file;
-    }
 
-    /// <summary>
-    ///   Generate a new Player Profile. Create savegames folder and relevant file structures. 
-    /// </summary>
-    /// <param name="scaffold">Boolean to determine whether to execute Scaffold generation.</param>
-    /// <param name="path"    >-path parameter to pass to Halo and write to profiles.</param>
-    /// <param name="profile" >Object to represent as string.</param>
-    public static void Profile(bool scaffold, string path, Profile profile)
-    {
-      /// todo:
-      ///   create the file.
-      ///     double check it
-      ///   DONE: if the file is still null, *then* throw an exception.
-      ///     Do this everywhere this function is called.
-      ///   populate with default settings
-      ///     blam.sav has some defaults listed. What needs to be set manually?
-      ///   load the file
-      ///     Do I still need to do this?
-      Core("Profile.Generate");
-      var file = new File();
-      SetNewName(profile);
-      profile.Path = Custom.Profile(path, profile.Details.Name);
+      /// Create or overwrite lastprof.txt
+      file.Path = Custom.LastProfile(path);
+      file.WriteAllBytes(new byte[0xFF]); /// 255 int. Makes room for up to 255 characters.
+      lastprofile.Path = file.Path;
+      lastprofile.Save();
+      VerifyPath(file.Path);
 
-      if (!scaffold)
-        Scaffold(path, profile, file);
-
-      profile.Save();
+      Info("Scaffold created.");
     }
   }
 }

--- a/src/Paths.cs
+++ b/src/Paths.cs
@@ -65,6 +65,11 @@ namespace HXE
         ? Combine(CurrentDirectory,  "initc.txt")
         : Combine(CurrentDirectory,  "init.txt");
 
+      public static string ProfileDirectory(string profile)
+      {
+        return Combine(Directory, Profiles, profile);
+      }
+
       public static string Profile(string profile)
       {
         return Combine(Directory, Profiles, profile, "blam.sav");
@@ -73,6 +78,11 @@ namespace HXE
       public static string Progress(string profile)
       {
         return Combine(Directory, Profiles, profile, "savegame.bin");
+      }
+
+      public static string Waypoint(string profile)
+      {
+        return Combine(Directory, Profiles, profile, profile);
       }
     }
 
@@ -98,14 +108,48 @@ namespace HXE
         return Combine(directory, "OpenSauce", "OS_Settings.User.xml");
       }
 
+      /// <summary>
+      /// Provide the -path parameter's string and a Player Profile name to get the path of its directory.
+      /// </summary>
+      /// <param name="directory">The path provided by the -path executable parameter.</param>
+      /// <param name="profile">The name of the provided Player Profile.</param>
+      /// <returns>The path of the Player Profile's directory.</returns>
+      public static string ProfileDirectory(string directory, string profile)
+      {
+        return Combine(directory, Profiles(directory), profile);
+      }
+
+      /// <summary>
+      /// Provide the -path parameter's string and a Player Profile name to get the path of its blam.sav file.
+      /// </summary>
+      /// <param name="directory">The path provided by the -path executable parameter.</param>
+      /// <param name="profile">The name of the provided Player Profile.</param>
+      /// <returns>The path to the Player Profile's blam.sav file.</returns>
       public static string Profile(string directory, string profile)
       {
         return Combine(directory, Profiles(directory), profile, "blam.sav");
       }
 
+      /// <summary>
+      /// Provide the -path parameter's string and a Player Profile name to get the path of its savegame.bin file.
+      /// </summary>
+      /// <param name="directory">The path provided by the -path executable parameter.</param>
+      /// <param name="profile">The name of the provided Player Profile.</param>
+      /// <returns>The path to the Player Profile's savegame.bin file.</returns>
       public static string Progress(string directory, string profile)
       {
         return Combine(directory, Profiles(directory), profile, "savegame.bin");
+      }
+
+      /// <summary>
+      /// Provide the -path parameter's string and a Player Profile name to get the path of its Waypoint file.
+      /// </summary>
+      /// <param name="directory">The path provided by the -path executable parameter.</param>
+      /// <param name="profile">The name of the provided Player Profile.</param>
+      /// <returns>The Path to the Player Profile's Waypoint file as a string.</returns>
+      public static string Waypoint(string directory, string profile)
+      {
+        return Combine(directory, Profiles(directory), profile, profile);
       }
     }
   }

--- a/src/Paths.cs
+++ b/src/Paths.cs
@@ -116,7 +116,7 @@ namespace HXE
       /// <returns>The path of the Player Profile's directory.</returns>
       public static string ProfileDirectory(string directory, string profile)
       {
-        return Combine(directory, Profiles(directory), profile);
+        return Combine(Profiles(directory), profile);
       }
 
       /// <summary>
@@ -127,7 +127,7 @@ namespace HXE
       /// <returns>The path to the Player Profile's blam.sav file.</returns>
       public static string Profile(string directory, string profile)
       {
-        return Combine(directory, Profiles(directory), profile, "blam.sav");
+        return Combine(Profiles(directory), profile, "blam.sav");
       }
 
       /// <summary>
@@ -138,7 +138,7 @@ namespace HXE
       /// <returns>The path to the Player Profile's savegame.bin file.</returns>
       public static string Progress(string directory, string profile)
       {
-        return Combine(directory, Profiles(directory), profile, "savegame.bin");
+        return Combine(Profiles(directory), profile, "savegame.bin");
       }
 
       /// <summary>
@@ -149,7 +149,7 @@ namespace HXE
       /// <returns>The Path to the Player Profile's Waypoint file as a string.</returns>
       public static string Waypoint(string directory, string profile)
       {
-        return Combine(directory, Profiles(directory), profile, profile);
+        return Combine(Profiles(directory), profile, profile);
       }
     }
   }

--- a/src/SPV3/Initiation.cs
+++ b/src/SPV3/Initiation.cs
@@ -20,7 +20,6 @@
 
 using System;
 using System.Text;
-using static System.IO.File;
 using static HXE.Console;
 using static HXE.SPV3.PostProcessing;
 


### PR DESCRIPTION
Previously known as ProfileGen and Generator. Autoprofile adds the functionality of creating every profile-related file under the -path parameter (even going as far as creating the directories if they don't exist).
This is done so users can select a new directory for player profiles and saved games without starting the game to go through the process of creating a new profile.

closes #31
closes #17 